### PR TITLE
Add docker-compose restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,6 @@ services:
     volumes:
       - ./config.json:/app/config.json
       - store:/app/store
+    restart: on-failure
 volumes:
   store:


### PR DESCRIPTION
This PR adds a restart policy for the docker-compose stack (see: https://github.com/compose-spec/compose-spec/blob/main/spec.md#restart). `always` tends to be funky across restarts, so I've chosen `on-failure` just to ensure that it's only restarted if the container crashes.
