### PR TITLE
Set syncingPresence to "offline" to prevent showing online constantly

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -51,6 +51,8 @@ client.on(
    */
   async (roomId, event) => {
     try {
+      await client.setPresenceStatus("unavailable");
+
       if (!ACTIVE_ROOMS.includes(roomId)) {
         return;
       }


### PR DESCRIPTION
I'm not sure if this will work, but it's taken from here:

- https://turt2live.github.io/matrix-bot-sdk/MatrixClient.ts.html#line63
- https://turt2live.github.io/matrix-bot-sdk/MatrixClient.html#syncingPresence

I _think_ this will make it so the bot's presence will show as "offline", which is preferable to showing as "online" constantly. Might need testing though!
