### PR TITLE
Ignore spaces in list bookmarks parse path

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -53,8 +53,8 @@ client.on(
         return;
       }
 
+      // Create bookmark with message
       if (
-        // Create bookmark with message
         event.type === "m.room.message" &&
         event?.content?.body?.startsWith("🔖")
       ) {
@@ -65,8 +65,8 @@ client.on(
         );
       }
 
+      // Create bookmark with reaction
       if (
-        // Create bookmark with reaction
         event.type === "m.reaction" &&
         event?.content?.["m.relates_to"]?.key === "🔖"
       ) {
@@ -160,8 +160,8 @@ client.on(
         listBookmarks(roomId);
       }
 
+      // List bookmarks
       if (event.type === "m.room.message" && event?.content?.body?.startsWith("📑")) {
-        // List bookmarks
         listBookmarks(roomId);
       }
     } catch (e) {


### PR DESCRIPTION
Previously, a space after the bookmark tabs emoji would prevent the bookmarks from being listed. This changes the check so that it ignores the rest of the message when checking to see if it starts with the bookmark tabs.
