### PR TITLE
Add more checkmark options for silent checkmarks

### DIFF
--- a/src/Host.js
+++ b/src/Host.js
@@ -21,7 +21,7 @@ function messageUrl(roomId, eventId) {
   return `https://matrix.to/#/${roomId}/${eventId}`;
 }
 
-const SILENT_CHECKMARKS = ["☑️", "✔️"];
+const SILENT_CHECKMARKS = ["☑️", "☑", "✔️", "✔", "✓"];
 const LOUD_CHECKMARKS = ["✅️", "✅"];
 const CHECKMARKS = [...SILENT_CHECKMARKS, ...LOUD_CHECKMARKS];
 


### PR DESCRIPTION
After deploying #16 we found that some checkmark emojis weren't appropriately checking things off. This adds a few more check mark variations which include (or exclude) the "Variation Selector `FF0F`" unicode augment.

Tested and verified this works!

